### PR TITLE
fix: Default value on server-side parsing

### DIFF
--- a/packages/next-usequerystate/src/parsers.test.ts
+++ b/packages/next-usequerystate/src/parsers.test.ts
@@ -54,4 +54,18 @@ describe('parsers', () => {
     // It encodes its separator
     expect(parser.serialize(['a', ',', 'b'])).toBe('a,%2C,b')
   })
+
+  test('parseServerSide with default (#384)', () => {
+    const p = parseAsString.withDefault('default')
+    const searchParams = {
+      string: 'foo',
+      stringArray: ['bar', 'egg'],
+      undef: undefined
+    }
+    expect(p.parseServerSide(searchParams.undef)).toBe('default')
+    expect(p.parseServerSide(searchParams.string)).toBe('foo')
+    expect(p.parseServerSide(searchParams.stringArray)).toBe('bar')
+    // @ts-expect-error - Implicitly undefined
+    expect(p.parseServerSide(searchParams.nope)).toBe('default')
+  })
 })

--- a/packages/next-usequerystate/src/parsers.ts
+++ b/packages/next-usequerystate/src/parsers.ts
@@ -74,7 +74,10 @@ export type ParserBuilder<T> = Required<Parser<T>> &
 export function createParser<T>(parser: Required<Parser<T>>): ParserBuilder<T> {
   return {
     ...parser,
-    parseServerSide(value = '') {
+    parseServerSide(value) {
+      if (typeof value === 'undefined') {
+        return null
+      }
       let str = ''
       if (Array.isArray(value)) {
         // Follow the spec:
@@ -94,7 +97,7 @@ export function createParser<T>(parser: Required<Parser<T>>): ParserBuilder<T> {
       return {
         ...this,
         defaultValue,
-        parseServerSide(value = '') {
+        parseServerSide(value) {
           return nullableParse(value) ?? defaultValue
         }
       }


### PR DESCRIPTION
When using a string parser with a default value, it wasn't properly handled due to an incorrect default assignment to an empty string to satisfy TypeScript.

Closes #384.