### PR TITLE
feat: Allow chaining parser options & default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,17 +279,12 @@ You can use a builder pattern to facilitate specifying all of those things:
 ```ts
 useQueryState(
   'counter',
-  parseAsInteger
-    .withOptions({
-      history: 'push',
-      shallow: false
-    })
-    .withDefault(0)
+  parseAsInteger.withDefault(0).withOptions({
+    history: 'push',
+    shallow: false
+  })
 )
 ```
-
-Note: `withDefault` must always come **after** `withOptions` to ensure proper
-type safety (providing a non-nullable state type).
 
 You can get this pattern for your custom parsers too, and compose them
 with others:

--- a/packages/next-usequerystate/src/parsers.test.ts
+++ b/packages/next-usequerystate/src/parsers.test.ts
@@ -68,4 +68,31 @@ describe('parsers', () => {
     // @ts-expect-error - Implicitly undefined
     expect(p.parseServerSide(searchParams.nope)).toBe('default')
   })
+
+  test('chaining options does not reset them', () => {
+    const p = parseAsString.withOptions({ scroll: true }).withOptions({})
+    expect(p.scroll).toBe(true)
+  })
+  test('chaining options merges them', () => {
+    const p = parseAsString
+      .withOptions({ scroll: true })
+      .withOptions({ history: 'push' })
+    expect(p.scroll).toBe(true)
+    expect(p.history).toBe('push')
+  })
+  test('chaining options & default value', () => {
+    const p = parseAsString
+      .withOptions({ scroll: true })
+      .withDefault('default')
+      .withOptions({ history: 'push' })
+    expect(p.scroll).toBe(true)
+    expect(p.history).toBe('push')
+    expect(p.defaultValue).toBe('default')
+    expect(p.parseServerSide(undefined)).toBe('default')
+  })
+  test('changing default value', () => {
+    const p = parseAsString.withDefault('foo').withDefault('bar')
+    expect(p.defaultValue).toBe('bar')
+    expect(p.parseServerSide(undefined)).toBe('bar')
+  })
 })

--- a/packages/next-usequerystate/src/tests/parsers.test-d.ts
+++ b/packages/next-usequerystate/src/tests/parsers.test-d.ts
@@ -1,0 +1,29 @@
+import { expectType } from 'tsd'
+import { parseAsString } from '../../dist'
+
+{
+  const p = parseAsString
+  expectType<string | null>(p.parse('foo'))
+  expectType<string>(p.serialize('foo'))
+  expectType<string | null>(p.parseServerSide(undefined))
+}
+
+{
+  const p = parseAsString.withOptions({}).withOptions({ scroll: true })
+  expectType<string | null>(p.parse('foo'))
+  expectType<string>(p.serialize('foo'))
+  expectType<string | null>(p.parseServerSide(undefined))
+}
+
+{
+  const p = parseAsString.withDefault('default')
+  expectType<string | null>(p.parse('foo')) // That one allows null
+  expectType<string>(p.parseServerSide(undefined)) // That one doesn't
+}
+
+{
+  // Adding options to a parser with a default value doesn't lose type safety
+  const p = parseAsString.withDefault('default').withOptions({ scroll: true })
+  expectType<string | null>(p.parse('foo'))
+  expectType<string>(p.parseServerSide(undefined))
+}

--- a/packages/next-usequerystate/src/tests/useQueryState.test-d.ts
+++ b/packages/next-usequerystate/src/tests/useQueryState.test-d.ts
@@ -257,14 +257,12 @@ import {
       parseAsInteger.withOptions({ scroll: true }).withDefault(1)
     )[0]
   )
-
-  expectError(() => {
-    // Can't set withOptions after withDefault
+  expectNotAssignable<null>(
     useQueryState(
       'foo',
       parseAsInteger.withDefault(1).withOptions({ scroll: true })
-    )
-  })
+    )[0]
+  )
 }
 
 // Expect errors on misuse -----------------------------------------------------

--- a/packages/playground/src/app/demos/server-side-parsing/client.tsx
+++ b/packages/playground/src/app/demos/server-side-parsing/client.tsx
@@ -16,13 +16,10 @@ export function ServerSideParsingDemoClient({
     'shallow',
     parseAsBoolean.withDefault(true)
   )
-  const [counter, setCounter] = useQueryState('counter', {
-    // Note that since the default value already has been specified,
-    // we can't use the .withOptions builder pattern here.
-    // However, we can spread and override the shallow option:
-    ...counterParser,
-    shallow
-  })
+  const [counter, setCounter] = useQueryState(
+    'counter',
+    counterParser.withOptions({ shallow })
+  )
 
   return (
     <>


### PR DESCRIPTION
Rather than adding another method, extend the types to allow chaining options and setting default values regardless of order.

Runtime was mostly fine except for a bug where re-setting a default value would not work for server-side parsing.

Closes #386.