### PR TITLE
feat: Add support for experimental WHS

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         base-path: ['/']
-        window-history-support: []
+        window-history-support: [false]
         next-version:
           - '13.4'
           - '13.5'
@@ -24,10 +24,10 @@ jobs:
           - next-version: '14.0.1'
             base-path: '/base'
           - next-version: canary
-            window-history-support: 'true'
+            window-history-support: true
           - next-version: canary
             base-path: '/base'
-            window-history-support: 'true'
+            window-history-support: true
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,9 @@ jobs:
     # branch protection settings for `next`.
     name: CI (${{ matrix.next-version }}${{ matrix.base-path && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
+      fail-fast: false
       matrix:
         # Watch out! When changing the compat grid,
         # update the required checks in GitHub
@@ -37,7 +39,7 @@ jobs:
           - next-version: canary
             base-path: '/base'
             window-history-support: true
-    continue-on-error: ${{ matrix.continue-on-error }}
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,19 +10,24 @@ env:
 
 jobs:
   ci:
-    name: Integration (Next.js ${{ matrix.next-version }}${{ matrix.base-path != '/' && ' with basePath' || ''}})
+    name: Integration (Next.js ${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support == 'true' && ' WHS' || ''}})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         base-path: ['/']
+        window-history-support: []
         next-version:
           - '13.4'
           - '13.5'
           - '14.0.1'
-          # - latest
         include:
           - next-version: '14.0.1'
             base-path: '/base'
+          - next-version: canary
+            window-history-support: 'true'
+          - next-version: canary
+            base-path: '/base'
+            window-history-support: 'true'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598
@@ -40,6 +45,7 @@ jobs:
         run: pnpm run test
         env:
           BASE_PATH: ${{ matrix.base-path }}
+          WINDOW_HISTORY_SUPPORT: ${{ matrix.window-history-support }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - uses: 47ng/actions-slack-notify@main
@@ -47,7 +53,7 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          jobName: next@${{ matrix.next-version }}
+          jobName: next@${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support == 'true' && ' WHS' || ''}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,14 +13,14 @@ jobs:
     # Watch out! When changing the job name,
     # update the required checks in GitHub
     # branch protection settings for `next`.
-    name: CI (${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
+    name: CI (${{ matrix.next-version }}${{ matrix.base-path && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Watch out! When changing the compat grid,
         # update the required checks in GitHub
         # branch protection settings for `next`.
-        base-path: ['/']
+        base-path: [false]
         window-history-support: [false]
         next-version:
           - '13.4'
@@ -50,7 +50,7 @@ jobs:
       - name: Run integration tests
         run: pnpm run test
         env:
-          BASE_PATH: ${{ matrix.base-path }}
+          BASE_PATH: ${{ matrix.base-path && matrix.base-path || '/' }}
           WINDOW_HISTORY_SUPPORT: ${{ matrix.window-history-support }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -59,7 +59,7 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          jobName: next@${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}}
+          jobName: next@${{ matrix.next-version }}${{ matrix.base-path && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
     # branch protection settings for `next`.
     name: CI (${{ matrix.next-version }}${{ matrix.base-path && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.continue-on-error }}
+    continue-on-error: ${{ matrix.next-version == 'canary' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +24,6 @@ jobs:
         # branch protection settings for `next`.
         base-path: [false]
         window-history-support: [false]
-        continue-on-error: [false]
         next-version:
           - '13.4'
           - '13.5'
@@ -33,7 +32,6 @@ jobs:
           - next-version: '14.0.1'
             base-path: '/base'
           - next-version: canary
-            continue-on-error: true
           - next-version: canary
             window-history-support: true
           - next-version: canary

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,7 @@ jobs:
         # branch protection settings for `next`.
         base-path: [false]
         window-history-support: [false]
+        continue-on-error: [false]
         next-version:
           - '13.4'
           - '13.5'
@@ -30,10 +31,13 @@ jobs:
           - next-version: '14.0.1'
             base-path: '/base'
           - next-version: canary
+            continue-on-error: true
+          - next-version: canary
             window-history-support: true
           - next-version: canary
             base-path: '/base'
             window-history-support: true
+    continue-on-error: ${{ matrix.continue-on-error }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,6 +33,8 @@ jobs:
             base-path: '/base'
           - next-version: canary
           - next-version: canary
+            base-path: '/base'
+          - next-version: canary
             window-history-support: true
           - next-version: canary
             base-path: '/base'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,6 +56,12 @@ jobs:
           WINDOW_HISTORY_SUPPORT: ${{ matrix.window-history-support }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      - name: Save Cypress artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        if: failure()
+        with:
+          path: packages/e2e/cypress/screenshots
+          name: ci-${{ matrix.next-version }}${{ matrix.base-path && '-basePath' || ''}}${{ matrix.window-history-support && '-whs' || ''}}
       - uses: 47ng/actions-slack-notify@main
         name: Notify on Slack
         if: always()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,10 +10,16 @@ env:
 
 jobs:
   ci:
-    name: Integration (Next.js ${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
+    # Watch out! When changing the job name,
+    # update the required checks in GitHub
+    # branch protection settings for `next`.
+    name: CI (${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Watch out! When changing the compat grid,
+        # update the required checks in GitHub
+        # branch protection settings for `next`.
         base-path: ['/']
         window-history-support: [false]
         next-version:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   ci:
-    name: Integration (Next.js ${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support == 'true' && ' WHS' || ''}})
+    name: Integration (Next.js ${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          jobName: next@${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support == 'true' && ' WHS' || ''}}
+          jobName: next@${{ matrix.next-version }}${{ matrix.base-path != '/' && ' basePath' || ''}}${{ matrix.window-history-support && ' WHS' || ''}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,23 +22,19 @@ jobs:
         # Watch out! When changing the compat grid,
         # update the required checks in GitHub
         # branch protection settings for `next`.
-        base-path: [false]
+        base-path: [false, '/base']
         window-history-support: [false]
         next-version:
           - '13.4'
           - '13.5'
           - '14.0.1'
+          - canary
         include:
-          - next-version: '14.0.1'
-            base-path: '/base'
-          - next-version: canary
-          - next-version: canary
-            base-path: '/base'
           - next-version: canary
             window-history-support: true
           - next-version: canary
-            base-path: '/base'
             window-history-support: true
+            base-path: '/base'
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Run integration tests
         run: pnpm run test
         env:
+          WINDOW_HISTORY_SUPPORT: 'true'
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - uses: 47ng/actions-slack-notify@main

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'cypress'
 const basePath =
   process.env.BASE_PATH === '/' ? '' : process.env.BASE_PATH ?? ''
 
+const windowHistorySupport =
+  process.env.WINDOW_HISTORY_SUPPORT === 'true' ? 'true' : 'undefined'
+
 export default defineConfig({
   e2e: {
     baseUrl: `http://localhost:3001${basePath}`,
@@ -12,7 +15,8 @@ export default defineConfig({
     testIsolation: true,
     retries: 5,
     env: {
-      basePath
+      basePath,
+      windowHistorySupport
     }
   }
 })

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -1,10 +1,18 @@
 import { defineConfig } from 'cypress'
+import fs from 'node:fs'
+
+const pkgPath = new URL('./package.json', import.meta.url)
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
 
 const basePath =
   process.env.BASE_PATH === '/' ? '' : process.env.BASE_PATH ?? ''
 
 const windowHistorySupport =
-  process.env.WINDOW_HISTORY_SUPPORT === 'true' ? 'true' : 'undefined'
+  pkg.dependencies.next >= '14.0.3-canary.6'
+    ? process.env.WINDOW_HISTORY_SUPPORT === 'true'
+      ? 'true'
+      : 'false'
+    : 'undefined'
 
 export default defineConfig({
   e2e: {

--- a/packages/e2e/cypress/e2e/internals.cy.js
+++ b/packages/e2e/cypress/e2e/internals.cy.js
@@ -6,6 +6,10 @@ describe('internals', () => {
     cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
     cy.get('#__N').should('have.text', 'undefined')
     cy.get('#__NA').should('have.text', 'true')
+    cy.get('#windowHistorySupport').should(
+      'have.text',
+      Cypress.env('windowHistorySupport')
+    )
   })
 
   it('works in pages router', () => {

--- a/packages/e2e/cypress/e2e/repro-388.cy.js
+++ b/packages/e2e/cypress/e2e/repro-388.cy.js
@@ -12,6 +12,7 @@ it('Reproduction for issue #388', () => {
   cy.get('#counter').should('have.text', 'Counter: 1')
   // Hover the "Hover me" link
   cy.get('#hover-me').trigger('mouseover')
+  cy.wait(100)
   // The URL should have a ?counter=1 query string
   cy.location('search').should('eq', '?counter=1')
   // The counter should be rendered as 1 on the page
@@ -26,6 +27,7 @@ it('Reproduction for issue #388', () => {
   cy.get('#counter').should('have.text', 'Counter: 1')
   // Mount the other link
   cy.get('#toggle').click()
+  cy.wait(100)
   // The URL should have a ?counter=1 query string
   cy.location('search').should('eq', '?counter=1')
   // The counter should be rendered as 1 on the page

--- a/packages/e2e/next.config.mjs
+++ b/packages/e2e/next.config.mjs
@@ -5,10 +5,18 @@ const experimental =
       }
     : undefined
 
+const basePath =
+  process.env.BASE_PATH === '/' ? undefined : process.env.BASE_PATH
+
 /** @type {import('next').NextConfig } */
 const config = {
-  basePath: process.env.BASE_PATH === '/' ? undefined : process.env.BASE_PATH,
+  basePath,
   experimental
 }
+
+console.info(`Next.js config:
+  basePath:             ${basePath}
+  windowHistorySupport: ${experimental?.windowHistorySupport ?? false}
+`)
 
 export default config

--- a/packages/e2e/next.config.mjs
+++ b/packages/e2e/next.config.mjs
@@ -1,10 +1,14 @@
+const experimental =
+  process.env.WINDOW_HISTORY_SUPPORT === 'true'
+    ? {
+        windowHistorySupport: true
+      }
+    : undefined
+
 /** @type {import('next').NextConfig } */
 const config = {
   basePath: process.env.BASE_PATH === '/' ? undefined : process.env.BASE_PATH,
-  experimental: {
-    windowHistorySupport:
-      process.env.WINDOW_HISTORY_SUPPORT === 'true' || undefined
-  }
+  experimental
 }
 
 export default config

--- a/packages/e2e/next.config.mjs
+++ b/packages/e2e/next.config.mjs
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig } */
 const config = {
-  basePath: process.env.BASE_PATH === '/' ? undefined : process.env.BASE_PATH
+  basePath: process.env.BASE_PATH === '/' ? undefined : process.env.BASE_PATH,
+  experimental: {
+    windowHistorySupport:
+      process.env.WINDOW_HISTORY_SUPPORT === 'true' || undefined
+  }
 }
 
 export default config

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -20,7 +20,7 @@
     "cypress:run": "cypress run --headless"
   },
   "dependencies": {
-    "next": "14.0.1",
+    "next": "14.0.3-canary.6",
     "next-usequerystate": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/e2e/src/app/app/internals/page.tsx
+++ b/packages/e2e/src/app/app/internals/page.tsx
@@ -11,6 +11,9 @@ export default function Page() {
     <>
       <p id="__N">{String(history.state.__N)}</p>
       <p id="__NA">{String(history.state.__NA)}</p>
+      <p id="windowHistorySupport">
+        {String(process.env.__NEXT_WINDOW_HISTORY_SUPPORT)}
+      </p>
     </>
   )
 }

--- a/packages/next-usequerystate/src/update-queue.ts
+++ b/packages/next-usequerystate/src/update-queue.ts
@@ -172,17 +172,23 @@ function flushUpdateQueue(router: Router): [URLSearchParams, null | unknown] {
 
 function renderURL(search: URLSearchParams) {
   const query = renderQueryString(search)
-  // @ts-expect-error - Not exposed in types
-  const basePath = window?.next?.router?.basePath ?? ''
-  const path = location.pathname.slice(basePath.length)
   const hash = location.hash
   if (history.state.__N === true) {
     // Pages router: always use a full path to handle dynamic routes
-    return query ? `${path}?${query}${hash}` : `${path}${hash}`
+    // @ts-expect-error - Not exposed in types
+    const basePath = window?.next?.router?.basePath ?? ''
+    const path = location.pathname.slice(basePath.length)
+    const base = process.env.__NEXT_WINDOW_HISTORY_SUPPORT
+      ? location.href.split('?')[0]
+      : path
+    return query ? `${base}?${query}${hash}` : `${base}${hash}`
   } else {
     // App router
-    // If the querystring is empty, add the pathname to clear it out,
-    // otherwise using a relative URL works just fine.
-    return query ? `?${query}${hash}` : `${path}${hash}`
+    // From 12.0.3-canary.6, with the experimental windowHistorySupport flag,
+    // a valid URL is required, so prepend the href (but without the query string)
+    const base = process.env.__NEXT_WINDOW_HISTORY_SUPPORT
+      ? location.href.split('?')[0]
+      : ''
+    return query ? `${base}?${query}${hash}` : `${base}${hash}`
   }
 }

--- a/packages/next-usequerystate/src/update-queue.ts
+++ b/packages/next-usequerystate/src/update-queue.ts
@@ -172,23 +172,20 @@ function flushUpdateQueue(router: Router): [URLSearchParams, null | unknown] {
 
 function renderURL(search: URLSearchParams) {
   const query = renderQueryString(search)
+  const href = location.href.split('?')[0]
   const hash = location.hash
   if (history.state.__N === true) {
-    // Pages router: always use a full path to handle dynamic routes
+    // Pages router: always use a full path to handle dynamic routes,
+    // but strip the basePath to avoid recursively applying it.
     // @ts-expect-error - Not exposed in types
     const basePath = window?.next?.router?.basePath ?? ''
     const path = location.pathname.slice(basePath.length)
-    const base = process.env.__NEXT_WINDOW_HISTORY_SUPPORT
-      ? location.href.split('?')[0]
-      : path
+    const base = process.env.__NEXT_WINDOW_HISTORY_SUPPORT ? href : path
     return query ? `${base}?${query}${hash}` : `${base}${hash}`
   } else {
     // App router
     // From 12.0.3-canary.6, with the experimental windowHistorySupport flag,
     // a valid URL is required, so prepend the href (but without the query string)
-    const base = process.env.__NEXT_WINDOW_HISTORY_SUPPORT
-      ? location.href.split('?')[0]
-      : ''
-    return query ? `${base}?${query}${hash}` : `${base}${hash}`
+    return query ? `${href}?${query}${hash}` : `${href}${hash}`
   }
 }

--- a/packages/next-usequerystate/src/useQueryState.ts
+++ b/packages/next-usequerystate/src/useQueryState.ts
@@ -237,6 +237,16 @@ export function useQueryState<T = string>(
     initialSearchParams?.get(key) ?? null
   )
 
+  if (process.env.__NEXT_WINDOW_HISTORY_SUPPORT) {
+    React.useEffect(() => {
+      const value = initialSearchParams.get(key) ?? null
+      const state = value === null ? null : parse(value)
+      debug(`[nuqs \`%s\`] syncFromUseSearchParams %O`, key, state)
+      stateRef.current = state
+      setInternalState(state)
+    }, [initialSearchParams?.get(key), key])
+  }
+
   // Sync all hooks together & with external URL changes
   React.useInsertionEffect(() => {
     function updateInternalState(state: T | null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
   packages/e2e:
     dependencies:
       next:
-        specifier: 14.0.1
-        version: 14.0.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.0.3-canary.6
+        version: 14.0.3-canary.6(react-dom@18.2.0)(react@18.2.0)
       next-usequerystate:
         specifier: workspace:*
         version: link:../next-usequerystate
@@ -611,12 +611,25 @@ packages:
   /@next/env@14.0.1:
     resolution: {integrity: sha512-Ms8ZswqY65/YfcjrlcIwMPD7Rg/dVjdLapMcSHG26W6O67EJDF435ShW4H4LXi1xKO1oRc97tLXUpx8jpLe86A==}
 
+  /@next/env@14.0.3-canary.6:
+    resolution: {integrity: sha512-tTTIcpA0QaZ0poNcsR2sHeuwIybn/3kyUIaig6RKh63UU7cHOaGZzwj/9+qY+Krx00QLDdbKxGb+d0Uu6Iqo7g==}
+    dev: false
+
   /@next/swc-darwin-arm64@14.0.1:
     resolution: {integrity: sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@next/swc-darwin-arm64@14.0.3-canary.6:
+    resolution: {integrity: sha512-Ja+2wV+X4l3REv4HiIskFHTj7SQUxZf2BnQjwwKzVpkdjDMCZCkUnACFlb4fFVP4cNl0d7w8qhosFnecrasw4g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-darwin-x64@14.0.1:
@@ -627,12 +640,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-darwin-x64@14.0.3-canary.6:
+    resolution: {integrity: sha512-bFLXAndkOIrKwD32Yb+3AubUvZfK1Z4XiUQxUDiJnBCWuYruYZ9fGuJ8ucsodRr71R1rthnno6M6M8hafWpcvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-arm64-gnu@14.0.1:
     resolution: {integrity: sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@14.0.3-canary.6:
+    resolution: {integrity: sha512-8ER9mlQL4jz1HmKK//Yv/MSG/EVk45NcCshg1SWE0TzcVr87N5dyBIPuw22GIVM2PSqo0Kf8vaNVn9Su4ErcJw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-arm64-musl@14.0.1:
@@ -643,12 +674,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-linux-arm64-musl@14.0.3-canary.6:
+    resolution: {integrity: sha512-tepB7suiUPFmjBvG25sMrfD59Z1Rz7GOkY1/C7iOHCxLicJ7Hk0ZNTFnHfB9R+KQewhSEhYXIPux89nnWz/qDw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-x64-gnu@14.0.1:
     resolution: {integrity: sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@next/swc-linux-x64-gnu@14.0.3-canary.6:
+    resolution: {integrity: sha512-MH8J2E//P2DQdIr8ed7kpnzsAiXOH2+fRKcpEptXf/b6pCd3hhQU3ZgY+bhbrQIyfJhFTvJ5gaewErr3WVi68w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-x64-musl@14.0.1:
@@ -659,12 +708,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-linux-x64-musl@14.0.3-canary.6:
+    resolution: {integrity: sha512-D3ETz2gF1Gh8l/ok7PwR51UDbnHti+HZxKMj8RD/XI89vzGjCHsoqG6/jZvU3EkNFxLy+7s8H2RxZ+i7FRqCFA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-arm64-msvc@14.0.1:
     resolution: {integrity: sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@14.0.3-canary.6:
+    resolution: {integrity: sha512-0VeorcCq2K1JO7zP0TpSvusf/lLrcREAYq0U/pb/yRTnrMzc8croNuiiMQwD3HJSeXYeib14wn/i8LZApE2fwQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-ia32-msvc@14.0.1:
@@ -675,12 +742,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-win32-ia32-msvc@14.0.3-canary.6:
+    resolution: {integrity: sha512-8o0c5d2IQQyMt/PsWdsYHvRFLVI2FxbgoBGDsqEYwKtXGgzHvLF9yh4cvYoCRDfmqfQ/ziH3YUO5NXL2FihOIA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-x64-msvc@14.0.1:
     resolution: {integrity: sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@next/swc-win32-x64-msvc@14.0.3-canary.6:
+    resolution: {integrity: sha512-cUyzas15zeQSH418+LtcMCDqu+CN9tJ7U57xAdkWmU6T8WMAy6E1UqKITgXz/fW8l/rz+g4AaHQQLBgQZ94Rdw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -3705,6 +3790,45 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  /next@14.0.3-canary.6(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Wn5ebhKQwbDG/RByKalJ8MufJhXvEyw7BZnJeDy2vFIU3wD0tcgvsi6/BPZemKvKPqJdcmSBRRrBBYQ/CcSrgg==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 14.0.3-canary.6
+      '@swc/helpers': 0.5.2
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001561
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
+      watchpack: 2.4.0
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.0.3-canary.6
+      '@next/swc-darwin-x64': 14.0.3-canary.6
+      '@next/swc-linux-arm64-gnu': 14.0.3-canary.6
+      '@next/swc-linux-arm64-musl': 14.0.3-canary.6
+      '@next/swc-linux-x64-gnu': 14.0.3-canary.6
+      '@next/swc-linux-x64-musl': 14.0.3-canary.6
+      '@next/swc-win32-arm64-msvc': 14.0.3-canary.6
+      '@next/swc-win32-ia32-msvc': 14.0.3-canary.6
+      '@next/swc-win32-x64-msvc': 14.0.3-canary.6
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}

--- a/turbo.json
+++ b/turbo.json
@@ -26,7 +26,7 @@
     },
     "e2e#test": {
       "dependsOn": ["build"],
-      "outputs": ["cypress/**"]
+      "outputs": ["cypress/**", "cypress.config.ts"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
     "e2e#build": {
       "outputs": [".next/**", "!.next/cache/**"],
       "dependsOn": ["^build"],
-      "env": ["BASE_PATH"]
+      "env": ["BASE_PATH", "WINDOW_HISTORY_SUPPORT"]
     },
     "playground#build": {
       "outputs": [".next/**", "!.next/cache/**"],


### PR DESCRIPTION
Starting from next@14.0.3-canary.6, you can turn on the experimental `windowHistorySupport` flag to solve issues with prefetch links.

There may be some optimisations to do since Next.js now also patches the history methods (and do so after nuqs), so it looks like there isn't a need for external sync anymore, but this first draft seems to work.

Adding a few more CI cases to test for non-regression.

Note: raw canary (without the flag) still fails due to prefetch reset (see #388), so PR https://github.com/vercel/next.js/pull/58297 is still much needed there. But now at leas the flag gives us an escape hatch.