### PR TITLE
fix: Restore compatibility with next@latest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,10 +27,12 @@ jobs:
           - '13.4'
           - '13.5'
           - '14.0.1'
+          # 14.0.2 is not compatible due to a prefetch issue
+          - latest
         include:
-          - next-version: canary
+          - next-version: latest
             window-history-support: true
-          - next-version: canary
+          - next-version: latest
             window-history-support: true
             base-path: '/base'
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Depending on your Next.js version:
 - Next.js <= 13.1: `next-usequerystate@1.7.2`
 - Next.js >= 13.4 && <= 14.0.1: `next-usequerystate@latest`
 - Next.js 14.0.2: Unfortunately not compatible due to a bug introduced in `next@14.0.2-canary.7`, see issue [#388](https://github.com/47ng/next-usequerystate/issues/388) and Next.js PR [#58297](https://github.com/vercel/next.js/pull/58297).
-- Next.js >= 14.0.3-canary-6: `next-usequerystate@latest` with the experimental flag [`windowHistorySupport`](https://github.com/vercel/next.js/pull/58335) set to `true`.
+- Next.js >= 14.0.3: `next-usequerystate@latest`
 
 </details>
 

--- a/packages/next-usequerystate/package.json
+++ b/packages/next-usequerystate/package.json
@@ -55,7 +55,7 @@
     "prepack": "./scripts/prepack.sh"
   },
   "peerDependencies": {
-    "next": "^13.4 || < 14.0.2"
+    "next": ">=13.4 <14.0.2 || ^14.0.3"
   },
   "dependencies": {
     "mitt": "^3.0.1"


### PR DESCRIPTION
This is to be released when next@14.0.3 lands.

- [x] Update semver compatibility range to `>=13.4 <14.0.2 || ^14.0.3`
- [x] Test `latest` against WHS true/false rather than canary (already tested on the canary-specific CI)
- [x] Update docs (version compatibility table)
- [x] ~Update CI to replace 14.0.1 with `latest` (and update branch protection to match)~ Keep 14.0.1 in tests.