### PR TITLE
Switch debug logging to `console.log`

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,7 @@ See issue #259 for more testing-related discussions.
 ## Debugging
 
 You can enable debug logs in the browser by setting the `debug` item in localStorage
-to `next-usequerystate`, and reload the page. 
-
-Make sure to set your Console Log Level to include "Verbose" (Chrome).
+to `next-usequerystate`, and reload the page.
 
 ```js
 // In your devtools:

--- a/README.md
+++ b/README.md
@@ -479,7 +479,9 @@ See issue #259 for more testing-related discussions.
 ## Debugging
 
 You can enable debug logs in the browser by setting the `debug` item in localStorage
-to `next-usequerystate` (or any string containing it), and reload the page.
+to `next-usequerystate`, and reload the page. 
+
+Make sure to set your Console Log Level to include "Verbose" (Chrome).
 
 ```js
 // In your devtools:

--- a/packages/next-usequerystate/src/debug.ts
+++ b/packages/next-usequerystate/src/debug.ts
@@ -9,7 +9,7 @@ export function debug(message: string, ...args: any[]) {
   }
   const msg = sprintf(message, ...args)
   performance.mark(msg)
-  console.debug(message, ...args)
+  console.log(message, ...args)
 }
 
 export function warn(message: string, ...args: any[]) {


### PR DESCRIPTION
* Change the debugging logging from `console.debug` to `console.log` so logging is visible without changing the log level to "verbose"
* Simplify readme wording in the debug section