### PR TITLE
bug_report template: Use emoji as checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,10 @@ Next.js information (obtained by running `next info`):
 
 Are you using:
 
-<!-- Remove the ✅ (is used) or the ✖️ (is not used): -->
+<!-- Keep whichever is relevant (✅: used, ❌ not used) -->
 
-- ✅/✖️ The app router
-- ✅/✖️ The pages router
+- ✅/❌ The app router
+- ✅/❌ The pages router
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,10 @@ Next.js information (obtained by running `next info`):
 
 Are you using:
 
-<!-- Replace the space between the square brackets with an x to tick the relevant box(es) -->
+<!-- Remove the ✅ (is used) or the ✖️ (is not used): -->
 
-- [ ] The app router
-- [ ] The pages router
+- ✅/✖️ The app router
+- ✅/✖️ The pages router
 
 ## Description
 


### PR DESCRIPTION
The checkboxes will show up as "tasks" on the issue summary "1 of 2 tasks done" wich is misleading since they are not tasks.


(https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md)