### PR TITLE
feat: Add support for transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ useQueryState hook for Next.js - Like React.useState, but stored in the URL quer
 - ♊️ Related querystrings with [`useQueryStates`](#usequerystates)
 - 📡 [Shallow mode](#shallow) by default for URL query updates, opt-in to notify server components
 - 🗃 _**new:**_ [Server cache](#accessing-searchparams-in-server-components) for type-safe searchParams access in nested server components
+- ⌛️ **new:** Support for [`useTransition`](#transitions) to get loading states on server updates
 
 ## Installation
 
@@ -317,6 +318,36 @@ setState('bar', { throttleMs: 1000 })
 If multiple hooks set different throttle values on the same event loop tick,
 the highest value will be used. Also, values lower than 50ms will be ignored,
 to avoid rate-limiting issues. [Read more](https://francoisbest.com/posts/2023/storing-react-state-in-the-url-with-nextjs#batching--throttling).
+
+### Transitions
+
+When combined with `shallow: false`, you can use the `useTransition` hook to get
+loading states while the server is re-rendering server components with the
+updated URL.
+
+Pass in the `startTransition` function from `useTransition` to the options
+to enable this behaviour _(this will set `shallow: false` automatically for you)_:
+
+```tsx
+'use client'
+
+import React from 'react'
+import { useQueryState, parseAsString } from 'next-usequerystate'
+
+function ClientComponent({ data }) {
+  const [isLoading, startTransition] = React.useTransition()
+  const [query, setQuery] = useQueryState(
+    'query',
+    parseAsString().withOptions({ startTransition })
+  )
+
+  // Indicate loading state
+  if (isLoading) return <div>Loading...</div>
+
+  // Normal rendering with data
+  return <div>{/*...*/}</div>
+}
+```
 
 ## Configuring parsers, default value & options
 

--- a/README.md
+++ b/README.md
@@ -335,11 +335,15 @@ import React from 'react'
 import { useQueryState, parseAsString } from 'next-usequerystate'
 
 function ClientComponent({ data }) {
+  // 1. Provide your own useTransition hook:
   const [isLoading, startTransition] = React.useTransition()
   const [query, setQuery] = useQueryState(
     'query',
+    // 2. Pass the `startTransition` as an option:
     parseAsString().withOptions({ startTransition })
   )
+  // 3. `isLoading` will be true while the server is re-rendering
+  // and streaming RSC payloads, when the query is updated via `setQuery`.
 
   // Indicate loading state
   if (isLoading) return <div>Loading...</div>

--- a/packages/e2e/cypress/e2e/transitions.cy.js
+++ b/packages/e2e/cypress/e2e/transitions.cy.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+it('transitions', () => {
+  cy.visit('/app/transitions')
+  cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+  cy.get('#server-rendered').should('have.text', '{}')
+  cy.get('#server-status').should('have.text', 'idle')
+  const button = cy.get('button')
+  button.should('have.text', '0')
+  button.click()
+  button.should('have.text', '1') // Instant setState
+  cy.get('#server-rendered').should('have.text', '{}')
+  cy.get('#server-status').should('have.text', 'loading')
+  cy.wait(500)
+  cy.get('#server-rendered').should('have.text', '{}')
+  cy.get('#server-status').should('have.text', 'loading')
+  cy.wait(500)
+  cy.get('#server-rendered').should('have.text', '{"counter":"1"}')
+  cy.get('#server-status').should('have.text', 'idle')
+})

--- a/packages/e2e/src/app/app/transitions/client.tsx
+++ b/packages/e2e/src/app/app/transitions/client.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { parseAsInteger, useQueryState } from 'next-usequerystate'
+import React from 'react'
+import { HydrationMarker } from '../../../components/hydration-marker'
+
+export function Client() {
+  const [isLoading, startTransition] = React.useTransition()
+  const [counter, setCounter] = useQueryState(
+    'counter',
+    parseAsInteger.withDefault(0).withOptions({ startTransition })
+  )
+  return (
+    <>
+      <HydrationMarker />
+      <p id="server-status">{isLoading ? 'loading' : 'idle'}</p>
+      <button onClick={() => setCounter(counter + 1)}>{counter}</button>
+    </>
+  )
+}

--- a/packages/e2e/src/app/app/transitions/page.tsx
+++ b/packages/e2e/src/app/app/transitions/page.tsx
@@ -1,0 +1,20 @@
+import { setTimeout } from 'node:timers/promises'
+import { Suspense } from 'react'
+import { Client } from './client'
+
+type PageProps = {
+  searchParams: Record<string, string | string[] | undefined>
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  await setTimeout(1000)
+  return (
+    <>
+      <h1>Transitions</h1>
+      <pre id="server-rendered">{JSON.stringify(searchParams)}</pre>
+      <Suspense>
+        <Client />
+      </Suspense>
+    </>
+  )
+}

--- a/packages/next-usequerystate/src/defs.ts
+++ b/packages/next-usequerystate/src/defs.ts
@@ -1,10 +1,18 @@
 import { useRouter } from 'next/navigation.js' // https://github.com/47ng/next-usequerystate/discussions/352
+import type { TransitionStartFunction } from 'react'
 
 export type Router = ReturnType<typeof useRouter>
 
 export type HistoryOptions = 'replace' | 'push'
 
-export type Options = {
+// prettier-ignore
+type StartTransition<T> = T extends false
+  ? TransitionStartFunction
+  : T extends true
+    ? never
+    : TransitionStartFunction
+
+export type Options<Shallow = unknown> = {
   /**
    * How the query update affects page history
    *
@@ -29,7 +37,7 @@ export type Options = {
    * Setting it to `false` will trigger a network request to the server with
    * the updated querystring.
    */
-  shallow?: boolean
+  shallow?: Extract<Shallow | boolean, boolean>
 
   /**
    * Maximum amount of time (ms) to wait between updates of the URL query string.
@@ -48,8 +56,10 @@ export type Options = {
    * `React.useTransition()` hook.
    *
    * Using this will set the `shallow` setting to `false` automatically.
+   * As a result, you can't set both `shallow: true` and `startTransition`
+   * in the same Options object.
    */
-  startTransition?: React.TransitionStartFunction
+  startTransition?: StartTransition<Shallow>
 }
 
 export type Nullable<T> = {

--- a/packages/next-usequerystate/src/defs.ts
+++ b/packages/next-usequerystate/src/defs.ts
@@ -41,6 +41,15 @@ export type Options = {
    * will not have any effect.
    */
   throttleMs?: number
+
+  /**
+   * Opt-in to observing Server Component loading states when doing
+   * non-shallow updates by passing a `startTransition` from the
+   * `React.useTransition()` hook.
+   *
+   * Using this will set the `shallow` setting to `false` automatically.
+   */
+  startTransition?: React.TransitionStartFunction
 }
 
 export type Nullable<T> = {

--- a/packages/next-usequerystate/src/parsers.ts
+++ b/packages/next-usequerystate/src/parsers.ts
@@ -15,7 +15,7 @@ export type ParserBuilder<T> = Required<Parser<T>> &
      * Note that you can override those options in individual calls to the
      * state updater function.
      */
-    withOptions<This>(this: This, options: Options): This
+    withOptions<This, Shallow>(this: This, options: Options<Shallow>): This
 
     /**
      * Specifying a default value makes the hook state non-nullable when the

--- a/packages/next-usequerystate/src/tests/parsers.test-d.ts
+++ b/packages/next-usequerystate/src/tests/parsers.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import { parseAsString } from '../../dist'
 
 {
@@ -26,4 +26,51 @@ import { parseAsString } from '../../dist'
   const p = parseAsString.withDefault('default').withOptions({ scroll: true })
   expectType<string | null>(p.parse('foo'))
   expectType<string>(p.parseServerSide(undefined))
+}
+
+// Shallow / startTransition interaction
+{
+  type RSTF = React.TransitionStartFunction
+  type MaybeBool = boolean | undefined
+  type MaybeRSTF = RSTF | undefined
+
+  expectType<MaybeBool>(parseAsString.withOptions({}).shallow)
+  expectType<MaybeRSTF>(parseAsString.withOptions({}).startTransition)
+  expectType<MaybeBool>(parseAsString.withOptions({ shallow: true }).shallow)
+  expectType<MaybeRSTF>(
+    parseAsString.withOptions({ shallow: true }).startTransition
+  )
+  expectType<MaybeBool>(parseAsString.withOptions({ shallow: false }).shallow)
+  expectType<MaybeRSTF>(
+    parseAsString.withOptions({ shallow: false }).startTransition
+  )
+  expectType<MaybeBool>(
+    parseAsString.withOptions({ startTransition: () => {} }).shallow
+  )
+  expectType<MaybeRSTF>(
+    parseAsString.withOptions({ startTransition: () => {} }).startTransition
+  )
+  // Allowed
+  parseAsString.withOptions({
+    shallow: false,
+    startTransition: () => {}
+  })
+  // Not allowed
+  expectError(() => {
+    parseAsString.withOptions({
+      shallow: true,
+      startTransition: () => {}
+    })
+  })
+  expectError(() => {
+    parseAsString.withOptions({
+      shallow: {}
+    })
+  })
+
+  expectError(() => {
+    parseAsString.withOptions({
+      startTransition: {}
+    })
+  })
 }

--- a/packages/next-usequerystate/src/tests/useQueryState.test-d.ts
+++ b/packages/next-usequerystate/src/tests/useQueryState.test-d.ts
@@ -290,3 +290,17 @@ import {
   expectError(() => setFoo(() => undefined))
   expectError(() => setBar(() => undefined))
 }
+
+// Shallow & startTransition interaction
+{
+  const [, set] = useQueryState('foo')
+  set('ok', { shallow: true })
+  set('ok', { shallow: false })
+  set('ok', { startTransition: () => {} })
+  expectError(() => {
+    set('nope', {
+      shallow: true,
+      startTransition: () => {}
+    })
+  })
+}

--- a/packages/next-usequerystate/src/update-queue.test.ts
+++ b/packages/next-usequerystate/src/update-queue.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test, vi } from 'vitest'
+import { compose } from './update-queue'
+
+describe('update-queue/compose', () => {
+  test('empty array', () => {
+    const final = vi.fn()
+    compose([], final)
+    expect(final).toHaveBeenCalledOnce()
+  })
+  test('one item', () => {
+    const a = vi
+      .fn()
+      .mockImplementation(x => x())
+      .mockName('a')
+    const final = vi.fn()
+    compose([a], final)
+    expect(a).toHaveBeenCalledOnce()
+    expect(final).toHaveBeenCalledOnce()
+    expect(a.mock.invocationCallOrder[0]).toBeLessThan(
+      final.mock.invocationCallOrder[0]!
+    )
+  })
+  test('several items', () => {
+    const a = vi.fn().mockImplementation(x => x())
+    const b = vi.fn().mockImplementation(x => x())
+    const c = vi.fn().mockImplementation(x => x())
+    const final = vi.fn()
+    compose([a, b, c], final)
+    expect(a).toHaveBeenCalledOnce()
+    expect(b).toHaveBeenCalledOnce()
+    expect(c).toHaveBeenCalledOnce()
+    expect(final).toHaveBeenCalledOnce()
+    expect(a.mock.invocationCallOrder[0]).toBeLessThan(
+      b.mock.invocationCallOrder[0]!
+    )
+    expect(b.mock.invocationCallOrder[0]).toBeLessThan(
+      c.mock.invocationCallOrder[0]!
+    )
+    expect(c.mock.invocationCallOrder[0]).toBeLessThan(
+      final.mock.invocationCallOrder[0]!
+    )
+  })
+})

--- a/packages/next-usequerystate/src/update-queue.ts
+++ b/packages/next-usequerystate/src/update-queue.ts
@@ -9,12 +9,13 @@ export const FLUSH_RATE_LIMIT_MS = getDefaultThrottle()
 
 type UpdateMap = Map<string, string | null>
 const updateQueue: UpdateMap = new Map()
-const queueOptions: Required<Options> = {
+const queueOptions: Required<Omit<Options, 'startTransition'>> = {
   history: 'replace',
   scroll: false,
   shallow: true,
   throttleMs: FLUSH_RATE_LIMIT_MS
 }
+const transitionsQueue: Set<React.TransitionStartFunction> = new Set()
 
 let lastFlushTimestamp = 0
 let flushPromiseCache: Promise<URLSearchParams> | null = null
@@ -36,6 +37,12 @@ export function enqueueQueryStringUpdate<Value>(
     queueOptions.scroll = true
   }
   if (options.shallow === false) {
+    queueOptions.shallow = false
+  }
+  if (options.startTransition) {
+    // Providing a startTransition function will
+    // cause the update to be non-shallow.
+    transitionsQueue.add(options.startTransition)
     queueOptions.shallow = false
   }
   queueOptions.throttleMs = Math.max(
@@ -117,8 +124,10 @@ function flushUpdateQueue(router: Router): [URLSearchParams, null | unknown] {
   // Work on a copy and clear the queue immediately
   const items = Array.from(updateQueue.entries())
   const options = { ...queueOptions }
+  const transitions = Array.from(transitionsQueue)
   // Restore defaults
   updateQueue.clear()
+  transitionsQueue.clear()
   queueOptions.history = 'replace'
   queueOptions.scroll = false
   queueOptions.shallow = true
@@ -153,12 +162,14 @@ function flushUpdateQueue(router: Router): [URLSearchParams, null | unknown] {
       window.scrollTo(0, 0)
     }
     if (!options.shallow) {
-      // Call the Next.js router to perform a network request
-      // and re-render server components.
-      router.replace(url, {
-        scroll: false,
-        // @ts-expect-error - pages router fix, but not exposed in navigation types
-        shallow: false
+      compose(transitions, () => {
+        // Call the Next.js router to perform a network request
+        // and re-render server components.
+        router.replace(url, {
+          scroll: false,
+          // @ts-expect-error - pages router fix, but not exposed in navigation types
+          shallow: false
+        })
       })
     }
     return [search, null]
@@ -175,4 +186,21 @@ function renderURL(search: URLSearchParams) {
   const href = location.href.split('?')[0]
   const hash = location.hash
   return href + query + hash
+}
+
+export function compose(
+  fns: React.TransitionStartFunction[],
+  final: () => void
+) {
+  const recursiveCompose = (index: number) => {
+    if (index === fns.length) {
+      return final()
+    }
+    const fn = fns[index]
+    if (!fn) {
+      throw new Error('Invalid transition function')
+    }
+    fn(() => recursiveCompose(index + 1))
+  }
+  recursiveCompose(0)
 }

--- a/packages/next-usequerystate/src/useQueryState.ts
+++ b/packages/next-usequerystate/src/useQueryState.ts
@@ -204,7 +204,8 @@ export function useQueryState<T = string>(
     throttleMs = FLUSH_RATE_LIMIT_MS,
     parse = x => x as unknown as T,
     serialize = String,
-    defaultValue = undefined
+    defaultValue = undefined,
+    startTransition
   }: Partial<UseQueryStateOptions<T>> & { defaultValue?: T } = {
     history: 'replace',
     scroll: false,
@@ -283,11 +284,12 @@ export function useQueryState<T = string>(
         history: options.history ?? history,
         shallow: options.shallow ?? shallow,
         scroll: options.scroll ?? scroll,
-        throttleMs: options.throttleMs ?? throttleMs
+        throttleMs: options.throttleMs ?? throttleMs,
+        startTransition: options.startTransition ?? startTransition
       })
       return scheduleFlushToURL(router)
     },
-    [key, history, shallow, scroll, throttleMs]
+    [key, history, shallow, scroll, throttleMs, startTransition]
   )
   return [internalState ?? defaultValue ?? null, update]
 }

--- a/packages/next-usequerystate/src/useQueryState.ts
+++ b/packages/next-usequerystate/src/useQueryState.ts
@@ -18,14 +18,14 @@ export type UseQueryStateReturn<Parsed, Default> = [
   Default extends undefined
     ? Parsed | null // value can't be null if default is specified
     : Parsed,
-  (
+  <Shallow>(
     value:
       | null
       | Parsed
       | ((
           old: Default extends Parsed ? Parsed : Parsed | null
         ) => Parsed | null),
-    options?: Options
+    options?: Options<Shallow>
   ) => Promise<URLSearchParams>
 ]
 
@@ -206,7 +206,9 @@ export function useQueryState<T = string>(
     serialize = String,
     defaultValue = undefined,
     startTransition
-  }: Partial<UseQueryStateOptions<T>> & { defaultValue?: T } = {
+  }: Partial<UseQueryStateOptions<T>> & {
+    defaultValue?: T
+  } = {
     history: 'replace',
     scroll: false,
     shallow: true,

--- a/packages/next-usequerystate/src/useQueryStates.ts
+++ b/packages/next-usequerystate/src/useQueryStates.ts
@@ -62,7 +62,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     history = 'replace',
     scroll = false,
     shallow = true,
-    throttleMs = FLUSH_RATE_LIMIT_MS
+    throttleMs = FLUSH_RATE_LIMIT_MS,
+    startTransition
   }: Partial<UseQueryStatesOptions> = {}
 ): UseQueryStatesReturn<KeyMap> {
   type V = Values<KeyMap>
@@ -152,12 +153,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           history: options.history ?? history,
           shallow: options.shallow ?? shallow,
           scroll: options.scroll ?? scroll,
-          throttleMs: options.throttleMs ?? throttleMs
+          throttleMs: options.throttleMs ?? throttleMs,
+          startTransition: options.startTransition ?? startTransition
         })
       }
       return scheduleFlushToURL(router)
     },
-    [keyMap, history, shallow, scroll]
+    [keyMap, history, shallow, scroll, throttleMs, startTransition]
   )
   return [internalState, update]
 }

--- a/packages/playground/src/app/demos/throttling/client.tsx
+++ b/packages/playground/src/app/demos/throttling/client.tsx
@@ -8,19 +8,25 @@ import { delayParser, queryParser } from './parsers'
 const autoFillMessage = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.`
 
 export function Client() {
-  const [serverDelay, setServerDelay] = useQueryState('serverDelay', {
-    ...delayParser,
-    shallow: false
-  })
+  const [isQueryLoading, startQueryTransition] = React.useTransition()
+  const [isDelayLoading, startDelayTransition] = React.useTransition()
+  const [serverDelay, setServerDelay] = useQueryState(
+    'serverDelay',
+    delayParser.withOptions({
+      startTransition: startDelayTransition
+    })
+  )
   const [clientDelay, setClientDelay] = useQueryState(
     'clientDelay',
     delayParser
   )
-  const [q, setQ] = useQueryState('q', {
-    ...queryParser,
-    throttleMs: clientDelay,
-    shallow: false
-  })
+  const [q, setQ] = useQueryState(
+    'q',
+    queryParser.withOptions({
+      throttleMs: clientDelay,
+      startTransition: startQueryTransition
+    })
+  )
   const router = useRouter()
 
   const timeoutRef = React.useRef<number>()
@@ -95,7 +101,17 @@ export function Client() {
         ) : (
           <button onClick={() => setIndex(1)}>Simulate typing</button>
         )}
+        <button
+          onClick={() => {
+            setQ('foo')
+            setServerDelay(500)
+          }}
+        >
+          Set both
+        </button>
         <p>Client state: {q || <em>empty</em>}</p>
+        <p>Query status: {isQueryLoading ? 'loading' : 'idle'}</p>
+        <p>Delay status: {isDelayLoading ? 'loading' : 'idle'}</p>
       </div>
     </>
   )


### PR DESCRIPTION
This lets non-shallow updates be notified of server rendering loading status, using an external `React.useTransition` hook.

Example usage:

```tsx
function ClientComponent() {
  // 1. Provide your own useTransition hook:
  const [isLoading, startTransition] = React.useTransition()
  const [query, setQuery] = useQueryState(
    'query',
    // 2. Pass the `startTransition` as an option:
    parseAsString().withOptions({ startTransition })
  )
  // 3. isLoading will be true while the server is re-rendering and streaming RSC payloads
  // when the query is updated via `setQuery`.
}
```

## Tasks

- [x] Investigate dangling `startTransition` functions in unmounted components (see below)
- [x] Improve type safety around the interaction of the `shallow` and `startTransition` options. Done in #410, thanks @Talent30 !
- [x] Add end-to-end tests
- [x] Add documentation

Things that need to be ironed out:

What happens if we were to call a `startTransition` on an unmounted component? Because the URL update is deferred, a query state update may cause the calling component to be unmounted, and its `startTransition` reference left dangling in the queue. ~This is an issue with state updates, is it the same for transitions, and how can we mitigate it?~ -> This is no longer an issue in React 18 apparently: https://github.com/reactwg/react-18/discussions/82

Closes #402.