### PR TITLE
Github: Add links to discussion to new issue screen

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Feature idea
+    url: https://github.com/47ng/next-usequerystate/discussions/new?category=ideas
+    about: Please share ideas for new features as discussion
+  - name: Question
+    url: https://github.com/47ng/next-usequerystate/discussions/new?category=q-a
+    about: Please use the discussions to ask the community for help


### PR DESCRIPTION
This will expand the UI on the new issues screen to direct users to use the discussion for feature requests.

You can see how that looks for example here https://github.com/openstreetmap/iD/issues/new/choose ([Template](https://github.com/openstreetmap/iD/blob/develop/.github/ISSUE_TEMPLATE/config.yml))