### PR TITLE
fix: 'Source on GitHub' urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ useQueryState hook for Next.js - Like React.useState, but stored in the URL quer
 ## Installation
 
 ```shell
-$ pnpm add next-usequerystate
+pnpm add next-usequerystate
 ```
 
 ```shell
-$ yarn add next-usequerystate
+yarn add next-usequerystate
 ```
 
 ```shell
-$ npm install next-usequerystate
+npm install next-usequerystate
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ useQueryState hook for Next.js - Like React.useState, but stored in the URL quer
 
 ```shell
 $ pnpm add next-usequerystate
+```
+
+```shell
 $ yarn add next-usequerystate
+```
+
+```shell
 $ npm install next-usequerystate
 ```
 

--- a/packages/playground/src/app/demos/basic-counter/page.tsx
+++ b/packages/playground/src/app/demos/basic-counter/page.tsx
@@ -33,7 +33,7 @@ export default function BasicCounterDemoPage() {
       </nav>
       <p>Counter: {counter}</p>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/basic-counter/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/basic-counter/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/batching/page.tsx
+++ b/packages/playground/src/app/demos/batching/page.tsx
@@ -36,7 +36,7 @@ export default function BuilderPatternDemoPage() {
         </code>
       </pre>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/batching/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/batching/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/builder-pattern/page.tsx
+++ b/packages/playground/src/app/demos/builder-pattern/page.tsx
@@ -28,7 +28,7 @@ export default function BuilderPatternDemoPage() {
         </em>
       </p>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/builder-pattern/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/builder-pattern/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/compound-parsers/page.tsx
+++ b/packages/playground/src/app/demos/compound-parsers/page.tsx
@@ -49,7 +49,7 @@ export default function CompoundParsersDemo() {
         </pre>
       </section>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/compound-parsers/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/compound-parsers/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/crosslink/page.tsx
+++ b/packages/playground/src/app/demos/crosslink/page.tsx
@@ -64,7 +64,7 @@ export default function CrosslinkDemoPage() {
         </code>
       </pre>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/crosslink/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/crosslink/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/custom-parser/page.tsx
+++ b/packages/playground/src/app/demos/custom-parser/page.tsx
@@ -101,7 +101,7 @@ export default function BasicCounterDemoPage() {
         <span>{sort.bar}</span>
       </nav>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/custom-parser/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/custom-parser/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/hex-colors/page.tsx
+++ b/packages/playground/src/app/demos/hex-colors/page.tsx
@@ -90,7 +90,7 @@ export default function HexColorsDemo() {
         }}
       ></div>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/hex-colors/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/hex-colors/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/parsers/page.tsx
+++ b/packages/playground/src/app/demos/parsers/page.tsx
@@ -132,7 +132,7 @@ export default function BasicCounterDemoPage() {
         </li>
       </ul>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/parsers/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/parsers/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/pretty-urls/page.tsx
+++ b/packages/playground/src/app/demos/pretty-urls/page.tsx
@@ -34,7 +34,7 @@ export default function PrettyURLsDemoPage() {
         </li>
       </ul>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/pretty-urls/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/pretty-urls/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/repro-359/page.tsx
+++ b/packages/playground/src/app/demos/repro-359/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
         </button>
       </div>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/repro-359/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/repro-359/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/repro-376/page.tsx
+++ b/packages/playground/src/app/demos/repro-376/page.tsx
@@ -38,7 +38,7 @@ export default function ReproPage() {
       </nav>
       <p>Query: {searchQueryUrl}</p>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/repro-376/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/repro-376/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/server-side-parsing/page.tsx
+++ b/packages/playground/src/app/demos/server-side-parsing/page.tsx
@@ -20,7 +20,7 @@ export default function ServerSideParsingDemo({ searchParams }: PageProps) {
         </ServerSideParsingDemoClient>
       </Suspense>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/server-side-parsing/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/server-side-parsing/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/subscribeToQueryUpdates/page.tsx
+++ b/packages/playground/src/app/demos/subscribeToQueryUpdates/page.tsx
@@ -31,7 +31,7 @@ export default function BuilderPatternDemoPage() {
         <em>Check the console</em>
       </p>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/subscribeToQueryUpdates/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/subscribeToQueryUpdates/page.tsx">
           Source on GitHub
         </a>
       </p>

--- a/packages/playground/src/app/demos/throttling/page.tsx
+++ b/packages/playground/src/app/demos/throttling/page.tsx
@@ -34,7 +34,7 @@ export default async function ThottlingDemoPage({ searchParams }: PageParams) {
         <Client />
       </Suspense>
       <p>
-        <a href="https://github.com/47ng/next-usequerystate/blob/next/src/app/demos/thottling/page.tsx">
+        <a href="https://github.com/47ng/next-usequerystate/blob/next/packages/playground/src/app/demos/throttling/page.tsx">
           Source on GitHub
         </a>
       </p>


### PR DESCRIPTION
### What happened?
'Source on GitHub' urls in each demo broke as a result of moving files to support the monorepo:
![image](https://github.com/47ng/next-usequerystate/assets/3030453/7bbaf7f0-ae4f-4233-a7d8-f45a8b07daa4)

### What changed?
I updated the urls to files in the playground folder.

### Validation
Urls point to the correct files in the repo.