### PR TITLE
fix: Deprecate `subscribeToQueryUpdates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,23 +615,6 @@ Running components that use the Next.js router in isolation requires mocking it,
 which is being [worked on](https://github.com/scottrippey/next-router-mock/pull/103)
 for the app router.
 
-If you wish to spy on changes in the URL query string, you can use
-`subscribeToQueryUpdates`:
-
-```ts
-import { subscribeToQueryUpdates } from 'next-usequerystate'
-
-React.useEffect(
-  () =>
-    subscribeToQueryUpdates(({ search, source }) => {
-      console.log(search.toString()) // URLSearchParams
-      console.log(source) // 'internal' | 'external'
-    }),
-  // This returns an unsubscribe function
-  []
-)
-```
-
 See issue #259 for more testing-related discussions.
 
 ## Debugging

--- a/packages/next-usequerystate/src/sync.ts
+++ b/packages/next-usequerystate/src/sync.ts
@@ -27,6 +27,14 @@ declare global {
   }
 }
 
+/**
+ * @deprecated Since Next.js introduced shallow routing in 14.0.3, this
+ * method is no longer needed as you can use `useSearchParams`, which will
+ * react to changes in the URL when the `windowHistorySupport` experimental flag
+ * is set.
+ * This method will be removed in `next-usequerystate@2.0.0`, when Next.js
+ * decides to land the `windowHistorySupport` flag in GA.
+ */
 export function subscribeToQueryUpdates(
   callback: (args: QueryUpdateNotificationArgs) => void
 ) {


### PR DESCRIPTION
It was broken in Next.js 14.0.3 due to shallow updates not calling the patched history methods, and fixed in Next.js 14.0.4.

However, since turning on the `windowHistorySupport` flag causes `useSearchParams` to be reactive to shallow URL query changes, there's no longer need for this method.

Marking it as deprecated now, and will be dropped along with other deprecations in v2.0.0 once WHS lands in GA.

Closes #422.