### PR TITLE
fix: Use a traditional useEffect for emitter registration

### DIFF
--- a/packages/next-usequerystate/src/useQueryState.ts
+++ b/packages/next-usequerystate/src/useQueryState.ts
@@ -251,7 +251,7 @@ export function useQueryState<T = string>(
   }
 
   // Sync all hooks together & with external URL changes
-  React.useInsertionEffect(() => {
+  React.useEffect(() => {
     function updateInternalState(state: T | null) {
       debug('[nuqs `%s`] updateInternalState %O', key, state)
       stateRef.current = state

--- a/packages/next-usequerystate/src/useQueryStates.ts
+++ b/packages/next-usequerystate/src/useQueryStates.ts
@@ -88,7 +88,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   )
 
   // Sync all hooks together & with external URL changes
-  React.useInsertionEffect(() => {
+  React.useEffect(() => {
     function updateInternalState(state: V) {
       debug('[nuq+ `%s`] updateInternalState %O', keys, state)
       stateRef.current = state


### PR DESCRIPTION
useInsertionEffect was a hack to be notified from navigation events in the same event loop tick as the Next.js router, but it causes issues with tRPC's SSR and it looks like we could get by with a simple useEffect.

Testing this in CI to see if it's a viable fix, and there'll be internal docs and scheduling code to update if all goes green.