### PR TITLE
test: Support for rewrites

### DIFF
--- a/packages/e2e/cypress/e2e/rewrites.cy.js
+++ b/packages/e2e/cypress/e2e/rewrites.cy.js
@@ -1,0 +1,10 @@
+/// <reference types="cypress" />
+
+it('Supports rewrites (server-side only)', () => {
+  cy.visit('/app/rewrites/source?through=original')
+  cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+  cy.get('#injected-server').should('have.text', 'by rewrites')
+  cy.get('#injected-client').should('have.text', 'null')
+  cy.get('#through-server').should('have.text', 'original')
+  cy.get('#through-client').should('have.text', 'original')
+})

--- a/packages/e2e/cypress/e2e/rewrites.cy.js
+++ b/packages/e2e/cypress/e2e/rewrites.cy.js
@@ -7,4 +7,14 @@ it('Supports rewrites (server-side only)', () => {
   cy.get('#injected-client').should('have.text', 'null')
   cy.get('#through-server').should('have.text', 'original')
   cy.get('#through-client').should('have.text', 'original')
+
+  cy.visit('/app/rewrites/source?injected=original')
+  cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+  cy.get('#injected-server').should('have.text', 'by rewrites')
+  cy.get('#injected-client').should('have.text', 'original')
+
+  cy.visit('/app/rewrites/source/match-query?injected=blocked')
+  cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+  cy.get('#injected-server').should('have.text', 'disallowed')
+  cy.get('#injected-client').should('have.text', 'blocked')
 })

--- a/packages/e2e/next.config.mjs
+++ b/packages/e2e/next.config.mjs
@@ -19,6 +19,11 @@ const config = {
     {
       source: '/app/rewrites/source',
       destination: '/app/rewrites/destination?injected=by+rewrites'
+    },
+    {
+      source: '/app/rewrites/source/match-query',
+      destination: '/app/rewrites/destination?injected=disallowed',
+      has: [{ type: 'query', key: 'injected', value: 'blocked' }]
     }
   ]
 }

--- a/packages/e2e/next.config.mjs
+++ b/packages/e2e/next.config.mjs
@@ -14,7 +14,13 @@ const basePath =
 /** @type {import('next').NextConfig } */
 const config = {
   basePath,
-  experimental
+  experimental,
+  rewrites: async () => [
+    {
+      source: '/app/rewrites/source',
+      destination: '/app/rewrites/destination?injected=by+rewrites'
+    }
+  ]
 }
 
 console.info(`Next.js config:

--- a/packages/e2e/src/app/app/rewrites/destination/client.tsx
+++ b/packages/e2e/src/app/app/rewrites/destination/client.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useQueryStates } from 'next-usequerystate'
+import { searchParams } from './searchParams'
+
+export function RewriteDestinationClient() {
+  const [{ injected, through }] = useQueryStates(searchParams)
+  return (
+    <>
+      <p>
+        Injected (client): <span id="injected-client">{injected}</span>
+      </p>
+      <p>
+        Through (client): <span id="through-client">{through}</span>
+      </p>
+    </>
+  )
+}

--- a/packages/e2e/src/app/app/rewrites/destination/page.tsx
+++ b/packages/e2e/src/app/app/rewrites/destination/page.tsx
@@ -1,0 +1,25 @@
+import type { SearchParams } from 'next-usequerystate/parsers'
+import { cache } from './searchParams'
+import { Suspense } from 'react'
+import { RewriteDestinationClient } from './client'
+
+export default function RewriteDestinationPage({
+  searchParams
+}: {
+  searchParams: SearchParams
+}) {
+  const { injected, through } = cache.parse(searchParams)
+  return (
+    <>
+      <p>
+        Injected (server): <span id="injected-server">{injected}</span>
+      </p>
+      <p>
+        Through (server): <span id="through-server">{through}</span>
+      </p>
+      <Suspense>
+        <RewriteDestinationClient />
+      </Suspense>
+    </>
+  )
+}

--- a/packages/e2e/src/app/app/rewrites/destination/searchParams.ts
+++ b/packages/e2e/src/app/app/rewrites/destination/searchParams.ts
@@ -1,0 +1,11 @@
+import {
+  createSearchParamsCache,
+  parseAsString
+} from 'next-usequerystate/parsers'
+
+export const searchParams = {
+  injected: parseAsString.withDefault('null'),
+  through: parseAsString.withDefault('null')
+}
+
+export const cache = createSearchParamsCache(searchParams)


### PR DESCRIPTION
There are definitely some caveats to look out for when using rewrites with search params.

One is that the server and client search params on the rewritten page may differ, as the client will always see the source search params, but only the server can see additional search params injected by the rewrite rule.

Adding tests to showcase the baseline behaviour, which seems logical once you start thinking about where rewrites sit in the request/response cycle.