### PR TITLE
Rebranding to `nuqs`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,3 +97,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Mirror to nuqs
+        run: ./packages/next-usequerystate/scripts/mirror.sh
+        working-directory: packages/next-usequerystate
+        continue-on-error: true
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ yarn add next-usequerystate
 npm install next-usequerystate
 ```
 
+> Note: the package is moving to a new name: `nuqs` :tada:
+>
+> The 1.x versions will be available under both names, but 2.x onwards will
+> only be published under `nuqs`.
+
 ### Which version should I use?
 
 | Next.js version range | Supported next-usequerystate version                                                                                                                          |
@@ -595,7 +600,7 @@ export function Server() {
 
 // client.tsx
 // prettier-ignore
-'use client'
+;'use client'
 
 import { useQueryStates } from 'next-usequerystate'
 import { coordinatesParsers } from './searchParams'
@@ -723,4 +728,4 @@ Made with ❤️ by [François Best](https://francoisbest.com)
 Using this package at work ? [Sponsor me](https://github.com/sponsors/franky47)
 to help with support and maintenance.
 
-![Project analytics and stats](https://repobeats.axiom.co/api/embed/042323b03b6ae1e039c89ac77e3cf0b0032c512e.svg "Repobeats analytics image")
+![Project analytics and stats](https://repobeats.axiom.co/api/embed/042323b03b6ae1e039c89ac77e3cf0b0032c512e.svg 'Repobeats analytics image')

--- a/packages/next-usequerystate/scripts/mirror.sh
+++ b/packages/next-usequerystate/scripts/mirror.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Place ourselves in the package directory
+cd "$(dirname "$0")/.."
+
+# Login to the npm registry
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+
+# Rename & publish the package
+pnpm pkg set name=nuqs
+pnpm publish
+
+# Cleanup
+rm -f .npmrc


### PR DESCRIPTION
Mirroring package publishing to both `next-usequerystate` and `nuqs` until the next major, where `next-usequerystate` will no longer update.